### PR TITLE
Adds watch tasks for headed build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
         },
         watch: {
           specs: {
-            files: 'specs/**/*Spec.js',
+            files: ['specs/**/*Spec.js', 'helpers/*Helper.js'],
             tasks: 'jasmine:headed:build'
           }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,10 +36,17 @@ module.exports = function(grunt) {
                     vendor: sparrowFiles.vendor.headed.concat(['vendor/moment.js'])
                 }
             }
+        },
+        watch: {
+          specs: {
+            files: 'specs/**/*Spec.js',
+            tasks: 'jasmine:headed:build'
+          }
         }
     });
 
     grunt.loadNpmTasks('grunt-contrib-jasmine');
+    grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.registerTask('default', ['jasmine:headless']);
 
     grunt.registerTask('headless', ['jasmine:headless']);

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Sparrow:
 3) type __'npm install'__ (requires [node](http://nodejs.org/))
 
 4) type __'grunt headed'__ to create specRunner.html (requires [grunt](http://gruntjs.com/))
-<br>__NOTE: Make sure you run this command after creating new spec/helper files and after upgrading Sparrow__
+<br>__NOTE: Make sure you run this command after creating new spec/helper files and after upgrading Sparrow__.
+You can also run `grunt watch` to build specRunner.html automatically when spec/helper files change.
 
 5) open __runner.html__ in a browser (tested with newest Chrome and FF)
 <br>__(NOTE: FF seems to allow running from the local filesystem.  Chrome requires running it from a web server)__

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-jasmine": "^0.8.1",
+    "grunt-contrib-watch": "^0.6.1",
     "jquery": "^2.1.3",
     "lodash": "^2.4.1"
   }


### PR DESCRIPTION
Enables users to run `grunt watch` in order to rebuild tests automatically when a spec or helper is changed.

Fixes #1 
